### PR TITLE
Bugfix: Fixed app crashing when getting image

### DIFF
--- a/dq-server/src/controllers/image.js
+++ b/dq-server/src/controllers/image.js
@@ -64,6 +64,7 @@ function getMongoBucket(bucketName) {
 async function getFilename(_id, collectionName){
 	const collection = mongoose.connection.db.collection(collectionName);
 	const result = await collection.findOne({'_id' : _id});
+	if (!result) return null;
 	return result.filename;	
 }
 

--- a/dq-server/src/routes/image.js
+++ b/dq-server/src/routes/image.js
@@ -27,15 +27,19 @@ router.get('/', asyncCatch(async (req, res) => {
 		res.status(404);
 		throw new Error('Image not found');
 	}
+	const filename = await getFilename(imageID, 'images.files');
+	if (!filename){
+		res.status(404);
+		throw new Error('Image not found');
+	}
+	const extension = path.extname(filename).slice(1);
 	await downloadImage(imageID, () => {
-		res.send('Image not found').status(404);
+		throw new Error('Error downloading image');
 	}, (chunk) => {	
 		res.write(chunk);
 	}, () => {
 		res.end();
 	});
-	const filename = await getFilename(imageID, 'images.files');
-	const extension = path.extname(filename).slice(1);
 	res.set('content-type', `image/${extension}`);
 }));
 


### PR DESCRIPTION
The server was trying to change a response's status after sending it, originating in the request for an image whose id wasn't on the collection but was associated with a question.